### PR TITLE
Fix certificate footer template.

### DIFF
--- a/lms/templates/certificates/_accomplishment-footer.html
+++ b/lms/templates/certificates/_accomplishment-footer.html
@@ -5,14 +5,6 @@
             <p class="copy copy-micro">${copyright_text}</p>
         </div>
         <nav class="footer-app-nav">
-            <!--<ul class="list list-legal">-->
-                <!--<li class="nav-item">-->
-                    <!--<a class="action btn btn-small btn-link" href="${company_tos_url}">${company_tos_urltext}</a>-->
-                <!--</li>-->
-                <!--<li class="nav-item">-->
-                    <!--<a class="action btn btn-small btn-link" href="${company_privacy_url}">${company_privacy_urltext}</a>-->
-                <!--</li>-->
-            <!--</ul>-->
         </nav>
     </footer>
 


### PR DESCRIPTION
unable using html comment  ``` <!-- ``` in mako template, so just remove it from the template file