### PR TITLE
Store the full name when retun for the first time from Noor sso

### DIFF
--- a/common/djangoapps/third_party_auth/models.py
+++ b/common/djangoapps/third_party_auth/models.py
@@ -260,10 +260,7 @@ class ProviderConfig(ConfigurationModel):
 
         # Set the registration form to use the `fullname` detail for the `name` field.
         # ilearn: Give preferene to FirstName and FamilyName (last_name)
-        if details.get('first_name') and details.get('last_name'):
-            registration_form_data['name'] = details.get('first_name') + " " + details.get('last_name')
-        else:
-            registration_form_data['name'] = details.get('fullname', '')
+        registration_form_data['name'] = details.get('fullname', '')
 
         # Get the username separately to take advantage of the de-duping logic
         # built into the pipeline. The provider cannot de-dupe because it can't

--- a/common/djangoapps/third_party_auth/models.py
+++ b/common/djangoapps/third_party_auth/models.py
@@ -259,7 +259,11 @@ class ProviderConfig(ConfigurationModel):
         details = pipeline_kwargs.get('details').copy()
 
         # Set the registration form to use the `fullname` detail for the `name` field.
-        registration_form_data['name'] = details.get('fullname', '')
+        # ilearn: Give preferene to FirstName and FamilyName (last_name)
+        if details.get('first_name') and details.get('last_name'):
+            registration_form_data['name'] = details.get('first_name') + " " + details.get('last_name')
+        else:
+            registration_form_data['name'] = details.get('fullname', '')
 
         # Get the username separately to take advantage of the de-duping logic
         # built into the pipeline. The provider cannot de-dupe because it can't

--- a/lms/djangoapps/student_account/views.py
+++ b/lms/djangoapps/student_account/views.py
@@ -123,7 +123,7 @@ def login_and_registration_form(request, initial_mode="login"):
     if is_sso:
         reg_form_dict = json.loads(form_descriptions['registration'])
         for i, f in enumerate(reg_form_dict['fields']):
-            if f['name'] in ('captcha', 'confirm_password', 'name'):
+            if f['name'] in ('captcha', 'confirm_password'):
                 reg_form_dict['fields'].pop(i)
         form_descriptions['registration'] = json.dumps(reg_form_dict)
 

--- a/lms/djangoapps/student_account/views.py
+++ b/lms/djangoapps/student_account/views.py
@@ -144,7 +144,7 @@ def login_and_registration_form(request, initial_mode="login"):
             'password_reset_form_desc': json.loads(form_descriptions['password_reset']),
             'account_creation_allowed': configuration_helpers.get_value(
                 'ALLOW_PUBLIC_ACCOUNT_CREATION', settings.FEATURES.get('ALLOW_PUBLIC_ACCOUNT_CREATION', True)),
-                'google_recaptcha_site_key': not is_sso and settings.GOOGLE_RECAPTCHA_DATA_SITE_KEY or '',
+                'google_recaptcha_site_key': settings.GOOGLE_RECAPTCHA_DATA_SITE_KEY,
                 'is_sso': is_sso,
                 'set_national_id_url': reverse('set_national_id')
         },

--- a/lms/djangoapps/student_account/views.py
+++ b/lms/djangoapps/student_account/views.py
@@ -120,13 +120,6 @@ def login_and_registration_form(request, initial_mode="login"):
         and third_party_auth.pipeline.running(request)
     )
 
-    if is_sso:
-        reg_form_dict = json.loads(form_descriptions['registration'])
-        for i, f in enumerate(reg_form_dict['fields']):
-            if f['name'] in ('captcha', 'confirm_password'):
-                reg_form_dict['fields'].pop(i)
-        form_descriptions['registration'] = json.dumps(reg_form_dict)
-
     # Otherwise, render the combined login/registration page
     context = {
         'data': {

--- a/lms/static/js/student_account/views/LoginView.js
+++ b/lms/static/js/student_account/views/LoginView.js
@@ -95,10 +95,10 @@
                     this.renderErrors(formErrorsTitle, [this.errorMessage]);
                 } else if (this.currentProvider) {
                     /* If we're already authenticated with a third-party
-                     * provider, try logging in. The easiest way to do this
-                     * is to simply submit the form.
+                     * provider, redirect to register page as the SSO
+                     * account is not linked yet.
                      */
-                    this.model.save();
+                     window.location = "/register";
                 }
 
                 // Display account activation success or error messages.

--- a/lms/static/js/student_account/views/RegisterView.js
+++ b/lms/static/js/student_account/views/RegisterView.js
@@ -65,11 +65,6 @@
                         }
                     }));
 
-                    if (this.isSSO) {
-                        $($(this.el).find('#register-username')[0]).attr('type', 'hidden');
-                        $($(this.el).find('label[for="register-username"]')[0]).css('cssText', 'display: none !important');
-                    }
-
                     this.postRender();
 
                     // Must be called after postRender, since postRender sets up $formFeedback.

--- a/lms/templates/student_account/login.underscore
+++ b/lms/templates/student_account/login.underscore
@@ -52,7 +52,8 @@
         <%= context.fields %>
 
         <div class="g-recaptcha" data-callback="setLoginRecaptcha"  data-expired-callback="resetLoginRecaptcha" data-sitekey="<%= context.googleRecaptchaSiteKey %>"></div>
-
-        <button type="submit" class="action action-primary action-update js-login login-button"><%- gettext("Sign in") %></button>
+        <% if (!context.currentProvider) { %>
+            <button type="submit" class="action action-primary action-update js-login login-button"><%- gettext("Sign in") %></button>
+        <% } %>
     </div>
 </form>

--- a/lms/templates/student_account/register.underscore
+++ b/lms/templates/student_account/register.underscore
@@ -48,7 +48,8 @@
     <% } %>
 
     <%= context.fields %>
-    <div class="g-recaptcha" data-callback="setRegisterRecaptcha"  data-expired-callback="resetRegisterRecaptcha" data-sitekey="<%- context.googleRecaptchaSiteKey %>"></div>
-
+    <% if (!context.currentProvider) { %>
+        <div class="g-recaptcha" data-callback="setRegisterRecaptcha"  data-expired-callback="resetRegisterRecaptcha" data-sitekey="<%- context.googleRecaptchaSiteKey %>"></div>
+    <% } %>
     <button type="submit" class="action action-primary action-update js-register register-button"><%- gettext("التسجيل") %></button>
 </form>

--- a/openedx/core/djangoapps/user_api/views.py
+++ b/openedx/core/djangoapps/user_api/views.py
@@ -1017,6 +1017,14 @@ class RegistrationView(APIView):
                                 field_name, default=field_overrides[field_name]
                             )
 
+                    # ilearn: Hide the name field, it will still store the value
+                    form_desc.override_field_properties(
+                       "name",
+                       label="",
+                       field_type="hidden",
+                       required=False
+                    )
+
                     # Hide the password field
                     form_desc.override_field_properties(
                         "password",

--- a/openedx/core/djangoapps/user_api/views.py
+++ b/openedx/core/djangoapps/user_api/views.py
@@ -189,6 +189,14 @@ class RegistrationView(APIView):
         "terms_of_service",
     ]
 
+    SSO_HIDDEN_FIELDS = [
+        "username",
+        "name",
+        "password",
+        "confirm_password",
+        "captcha"
+    ]
+
     # This end-point is available to anonymous users,
     # so do not require authentication.
     authentication_classes = []
@@ -311,6 +319,17 @@ class RegistrationView(APIView):
                         form_desc,
                         required=self._is_field_required(field_name)
                     )
+
+            # ilearn: No SSO, we can enforce captcha
+            form_desc.add_field(
+                "captcha",
+                field_type="hidden",
+                required=True,
+                error_messages={
+                    "required": _("Please verify reCAPTCHA.")
+                }
+            )
+
         else:
             # Go through the fields in the fields order and add them if they are required or visible
             for field_name in self.field_order:
@@ -1017,24 +1036,17 @@ class RegistrationView(APIView):
                                 field_name, default=field_overrides[field_name]
                             )
 
-                    # ilearn: Hide the name field, it will still store the value
-                    form_desc.override_field_properties(
-                       "name",
-                       label="",
-                       field_type="hidden",
-                       required=False
-                    )
+                    # ilearn: Hide the fields which should not be filled by user in case of sso
+                    for field_name in self.SSO_HIDDEN_FIELDS:
+                        form_desc.override_field_properties(
+                            field_name,
+                            field_type="hidden",
+                            required=False,
+                            label="",
+                            instructions="",
+                            restrictions={}
+                        )
 
-                    # Hide the password field
-                    form_desc.override_field_properties(
-                        "password",
-                        default="",
-                        field_type="hidden",
-                        required=False,
-                        label="",
-                        instructions="",
-                        restrictions={}
-                    )
                     # used to identify that request is running third party social auth
                     form_desc.add_field(
                         "social_auth_provider",

--- a/openedx/core/djangoapps/user_api/views.py
+++ b/openedx/core/djangoapps/user_api/views.py
@@ -341,15 +341,6 @@ class RegistrationView(APIView):
                         required=self._is_field_required(field_name)
                     )
 
-        form_desc.add_field(
-            "captcha",
-            field_type="hidden",
-            required=True,
-            error_messages={
-                "required": _("Please verify reCAPTCHA.")
-            }
-        )
-
         return HttpResponse(form_desc.to_json(), content_type="application/json")
 
     @method_decorator(csrf_exempt)
@@ -488,6 +479,7 @@ class RegistrationView(APIView):
 
         form_desc.add_field(
             "confirm_email",
+            field_type="email",
             label=email_label,
             placeholder=email_placeholder,
             required=required,


### PR DESCRIPTION
As per the default function of open edX every known field returned from SAML response will be stored and auto filled at registration page (Visible after login at sso for the first time).

We just need to hide(at registration page for sso users) some of them like username and name (still we are storing them).

This PR includes the code which will be in effect if the SAML response contains the proper user information.