### PR TITLE
Disable option for email settings on dashboard if feature is not turned on

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -797,7 +797,9 @@ def dashboard(request):
         enrollment.course_id for enrollment in course_enrollments if (
             BulkEmailFlag.feature_enabled(enrollment.course_id)
         )
-    )
+    ) if (
+        settings.FEATURES.get("SHOW_EMAIL_SETTINGS_ON_DASHBOARD")
+    ) else []
 
     # Verification Attempts
     # Used to generate the "you must reverify for course x" banner


### PR DESCRIPTION
**After this change users won't see** the option "إعدادات عنوان البريد الإلكتروني " in settings menu against each course on dashboard.

### To revert this (To show the option back) one need to add following settings in lms.env.json:

FEATURES = {
...
SHOW_EMAIL_SETTINGS_ON_DASHBOARD: true, 
...
}